### PR TITLE
Update `nbconvert` to version `6.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.2.0" %}
+{% set version = "6.3.0" %}
 
 package:
   name: nbconvert
@@ -6,13 +6,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbconvert/nbconvert-{{ version }}.tar.gz
-  sha256: 16ceecd0afaa8fd26c245fa32e2c52066c02f13aa73387fffafd84750baea863
+  sha256: 5e77d6203854944520105e38f2563a813a4a3708e8563aa598928a3b5ee1081a
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - jupyter-nbconvert = nbconvert.nbconvertapp:main
+    - jupyter-dejavu = nbconvert.nbconvertapp:dejavu_main
   skip: True  #[py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.1.0" %}
+{% set version = "6.2.0" %}
 
 package:
   name: nbconvert
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbconvert/nbconvert-{{ version }}.tar.gz
-  sha256: d22a8ff202644d31db254d24d52c3a96c82156623fcd7c7f987bba2612303ec9
+  sha256: 16ceecd0afaa8fd26c245fa32e2c52066c02f13aa73387fffafd84750baea863
 
 build:
   number: 0


### PR DESCRIPTION

  `nbconver` version `6.2.0`
1. check the upstream
    https://github.com/jupyter/nbconvert/tree/6.2.0
  
2. check the pinnings
    https://github.com/jupyter/nbconvert/blob/6.2.0/setup.py

3. check the changelogs
    https://nbconvert.readthedocs.io/en/latest/changelog.html
  
4. additional research
   https://github.com/conda-forge/nbconvert-feedstock/issues

   There are currently some open issues mentioned in 
   conda-forge but they seem to be related to permissions in some directories, document formats and optional requirements, however there seem to be solutions discussed for this issues in the comments. 

5. verify dev_url
  https://github.com/jupyter/nbconvert
  
6. verify doc_url
  http://nbconvert.readthedocs.org/
  
7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `nbconver` package version `6.2.0` the folowing
command was used:
`conda build nbconver-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is relatively safe to update `nbconver` to version `6.2.0`
