### PR TITLE
Update `nbconvert` to version `6.4.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.3.0" %}
+{% set version = "6.4.1" %}
 
 package:
   name: nbconvert
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbconvert/nbconvert-{{ version }}.tar.gz
-  sha256: 5e77d6203854944520105e38f2563a813a4a3708e8563aa598928a3b5ee1081a
+  sha256: 7dce3f977c2f9651841a3c49b5b7314c742f24dd118b99e51b8eec13c504f555
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - nbclient >=0.5.0,<0.6.0
     - jupyterlab_pygments
   run_constrained:
-    - pyppeteer ==0.2.2
+    - pyppeteer ==0.2.6
 
 test:
   imports:
@@ -62,7 +62,7 @@ test:
     - jupyter nbconvert nbconvert/tests/files/notebook1.ipynb --to html
 
 about:
-  home: http://jupyter.org
+  home: https://jupyter.org
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
@@ -71,7 +71,7 @@ about:
     The nbconvert tool, jupyter nbconvert, converts notebooks to various other
     formats via Jinja templates. The nbconvert tool allows you to convert an
     .ipynb notebook file into various static formats.
-  doc_url: http://nbconvert.readthedocs.org/
+  doc_url: https://nbconvert.readthedocs.org/
   dev_url: https://github.com/jupyter/nbconvert
 
 extra:


### PR DESCRIPTION

  `nbconvert` version `6.4.1`
1. - [x] check the upstream
    https://github.com/jupyter/nbconvert/tree/6.4.1

2. - [x] check the pinnings

`pinnings for pyppeteer were updated`
https://github.com/jupyter/nbconvert/blob/6.4.1/setup.py#L230

The minimum version of `python` required is `3.7`
https://github.com/jupyter/nbconvert/blob/6.4.1/setup.py#L191

3. - [x] check the changelogs

https://github.com/jupyter/nbconvert/blob/6.4.1/docs/source/changelog.rst

4. - [x] additional research

    https://github.com/conda-forge/nbconvert-feedstock/issues

    there are some open issues mentioned in `conda-forge`

5. - [x] verify dev_url
    https://github.com/jupyter/nbconvert

6. - [x] verify doc_url
    https://nbconvert.readthedocs.org/

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
10. - [x] verify setuptools
      `setuptools` is in the recipe
11. - [x] verify wheel
      `wheel` is in the recipe
12. - [x] pip in the test section
       `pip` is in the test section
13. - [x] veriy the test section

Results:
- All checks have passed


Based on the research findings and the results we can conclude
that it is safe to update `nbconvert` to version `6.4.1`
