### PR TITLE
nbconvert 6.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.4.1" %}
+{% set version = "6.4.4" %}
 
 package:
   name: nbconvert
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbconvert/nbconvert-{{ version }}.tar.gz
-  sha256: 7dce3f977c2f9651841a3c49b5b7314c742f24dd118b99e51b8eec13c504f555
+  sha256: ee0dfe34bbd1082ac9bfc750aae3c73fcbc34a70c5574c6986ff83c10a3541fd
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,9 @@ requirements:
     - defusedxml
     - nbclient >=0.5.0,<0.6.0
     - jupyterlab_pygments
+    - beautifulsoup4
   run_constrained:
-    - pyppeteer ==0.2.6
+    - pyppeteer >=1,<1.1
 
 test:
   imports:
@@ -56,6 +57,7 @@ test:
 
   requires:
     - pip
+    - beautifulsoup4
   commands:
     - pip check
     - jupyter nbconvert --help


### PR DESCRIPTION
Update nbconvert to 6.4.4

We do not build nbconvert v6.4.5 because it splits the outputs https://github.com/conda-forge/nbconvert-feedstock/blob/main/recipe/meta.yaml

Changelog: https://github.com/jupyter/nbconvert/blob/6.4.4/docs/source/changelog.rst
Upstream setup.py: https://github.com/jupyter/nbconvert/blob/6.4.4/setup.py

Actions:
1. Add `beautifulsoup4` in run and test/requires
2. Update pinning for `pyppeteer >=1,<1.1` in run_constrained