### PR TITLE
nbconvert 7.17.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbconvert" %}
-{% set version = "7.16.6" %}
+{% set version = "7.17.0" %}
 
 # from nbconvert/utils/pandoc.py
 {% set min_pandoc = "2.9.2" %}
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 576a7e37c6480da7b8465eefa66c17844243816ce1ccc372633c6b71c3c0f582
+  sha256: 1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,7 @@ source:
 
 build:
   number: {{ build }}
-  # An indirect jupyterlab dependency through ipywidgets -> jupyterlab_widgets
-  # isn't available on s390x
-  skip: True  #[py<38 or s390x]
+  skip: True  #[py<38]
 
 requirements:
   host:
@@ -152,7 +150,7 @@ outputs:
         # Segmantation fault on osx:
         # PasteBoard: Error creating pasteboard: m.apple.pasteboard.clipboard [-4960]
         #- jupyter nbconvert tests/files/notebook2.ipynb --debug --allow-errors --to qtpdf  # [not linux]
-        # xelatex is required on linux imlicitely, see https://github.com/jupyter/nbconvert/blob/v7.16.4/nbconvert/exporters/pdf.py#L62-L64 
+        # xelatex is required on linux imlicitely, see https://github.com/jupyter/nbconvert/blob/v7.16.4/nbconvert/exporters/pdf.py#L62-L64
         # - xvfb-run -a jupyter nbconvert tests/files/notebook2.ipynb --debug --allow-errors --to qtpdf  # [linux]
 
     about:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12286](https://anaconda.atlassian.net/browse/PKG-12286)
- [Upstream repository](https://github.com/jupyter/nbconvert/tree/v7.17.0)
- [Upstream changelog/diff](https://github.com/jupyter/nbconvert/blob/v7.17.0/CHANGELOG.md)

### Explanation of changes:

- Update version and sha256
- Recipe cleanup
- Enable python 3.14 builds


[PKG-12286]: https://anaconda.atlassian.net/browse/PKG-12286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ